### PR TITLE
Add universal mlflow.autolog() function! (#3561)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -88,6 +88,8 @@ def pytest_ignore_collect(path, config):
             "tests/models",
             "tests/shap",
             "tests/utils/test_model_utils.py",
+            # this test is included here because it imports many big libraries like tf, keras, etc
+            "tests/tracking/fluent/test_fluent_autolog.py",
         ]
 
         relpath = os.path.relpath(str(path))

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -23,6 +23,7 @@ pytest --verbose tests/spacy --large
 pytest --verbose tests/fastai --large
 pytest --verbose tests/shap --large
 pytest --verbose tests/utils/test_model_utils.py --large
+pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
 
 
 test $err = 0

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -106,6 +106,7 @@ set_tags = mlflow.tracking.fluent.set_tags
 delete_experiment = mlflow.tracking.fluent.delete_experiment
 delete_run = mlflow.tracking.fluent.delete_run
 register_model = mlflow.tracking._model_registry.fluent.register_model
+autolog = mlflow.tracking.fluent.autolog
 
 
 run = projects.run
@@ -140,6 +141,7 @@ __all__ = [
     "get_registry_uri",
     "set_registry_uri",
     "list_run_infos",
+    "autolog",
     # model flavors
     "fastai",
     "gluon",

--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -3,16 +3,19 @@ import logging
 import sys
 import threading
 import uuid
+import gorilla
 
 from py4j.java_gateway import CallbackServerParameters
 
 from pyspark import SparkContext
+from pyspark.sql import SparkSession
 from mlflow.utils._spark_utils import _get_active_spark_session
 
 import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.context.abstract_context import RunContextProvider
+from mlflow.utils.autologging_utils import wrap_patch
 
 _JAVA_PACKAGE = "org.mlflow.spark.autologging"
 _SPARK_TABLE_INFO_TAG_NAME = "sparkDatasourceInfo"
@@ -89,57 +92,76 @@ def _set_run_tag(run_id, path, version, data_format):
     client.set_tag(run_id, _SPARK_TABLE_INFO_TAG_NAME, new_table_info)
 
 
-def autolog():
-    """Implementation of Spark datasource autologging"""
+def _listen_for_spark_activity(spark_context):
     global _spark_table_info_listener
-    if _get_current_listener() is None:
-        active_session = _get_active_spark_session()
-        if active_session is None:
-            raise MlflowException(
-                "No active SparkContext found, refusing to enable Spark datasource "
-                "autologging. Please create a SparkSession e.g. via "
-                "SparkSession.builder.getOrCreate() (see API docs at "
-                "https://spark.apache.org/docs/latest/api/python/"
-                "pyspark.sql.html#pyspark.sql.SparkSession) "
-                "before attempting to enable autologging"
-            )
+    if _get_current_listener() is not None:
+        return
+
+    if _get_spark_major_version(spark_context) < 3:
+        raise MlflowException("Spark autologging unsupported for Spark versions < 3")
+
+    gw = spark_context._gateway
+    params = gw.callback_server_parameters
+    callback_server_params = CallbackServerParameters(
+        address=params.address,
+        port=params.port,
+        daemonize=True,
+        daemonize_connections=True,
+        eager_load=params.eager_load,
+        ssl_context=params.ssl_context,
+        accept_timeout=params.accept_timeout,
+        read_timeout=params.read_timeout,
+        auth_token=params.auth_token,
+    )
+    callback_server_started = gw.start_callback_server(callback_server_params)
+
+    event_publisher = _get_jvm_event_publisher()
+    try:
+        event_publisher.init(1)
+        _spark_table_info_listener = PythonSubscriber()
+        _spark_table_info_listener.register()
+    except Exception as e:
+        if callback_server_started:
+            try:
+                gw.shutdown_callback_server()
+            except Exception as e:  # pylint: disable=broad-except
+                _logger.warning(
+                    "Failed to shut down Spark callback server for autologging: %s", str(e)
+                )
+        _spark_table_info_listener = None
+        raise MlflowException(
+            "Exception while attempting to initialize JVM-side state for "
+            "Spark datasource autologging. Please create a new Spark session "
+            "and ensure you have the mlflow-spark JAR attached to your Spark "
+            "session as described in "
+            "http://mlflow.org/docs/latest/tracking.html#"
+            "automatic-logging-from-spark-experimental. "
+            "Exception:\n%s" % e
+        )
+
+    # Register context provider for Spark autologging
+    from mlflow.tracking.context.registry import _run_context_provider_registry
+
+    _run_context_provider_registry.register(SparkAutologgingContext)
+
+    _logger.info("Autologging successfully enabled for spark.")
+
+
+def autolog():
+    def __init__(self, *args, **kwargs):
+        original = gorilla.get_original_attribute(SparkSession, "__init__")
+        original(self, *args, **kwargs)
+
+        _listen_for_spark_activity(self._sc)
+
+    wrap_patch(SparkSession, "__init__", __init__)
+
+    active_session = _get_active_spark_session()
+    if active_session is not None:
         # We know SparkContext exists here already, so get it
         sc = SparkContext.getOrCreate()
-        if _get_spark_major_version(sc) < 3:
-            raise MlflowException("Spark autologging unsupported for Spark versions < 3")
-        gw = active_session.sparkContext._gateway
-        params = gw.callback_server_parameters
-        callback_server_params = CallbackServerParameters(
-            address=params.address,
-            port=params.port,
-            daemonize=True,
-            daemonize_connections=True,
-            eager_load=params.eager_load,
-            ssl_context=params.ssl_context,
-            accept_timeout=params.accept_timeout,
-            read_timeout=params.read_timeout,
-            auth_token=params.auth_token,
-        )
-        gw.start_callback_server(callback_server_params)
 
-        event_publisher = _get_jvm_event_publisher()
-        try:
-            event_publisher.init(1)
-            _spark_table_info_listener = PythonSubscriber()
-            _spark_table_info_listener.register()
-        except Exception as e:
-            raise MlflowException(
-                "Exception while attempting to initialize JVM-side state for "
-                "Spark datasource autologging. Please ensure you have the "
-                "mlflow-spark JAR attached to your Spark session as described "
-                "in http://mlflow.org/docs/latest/tracking.html#"
-                "automatic-logging-from-spark-experimental. Exception:\n%s" % e
-            )
-
-        # Register context provider for Spark autologging
-        from mlflow.tracking.context.registry import _run_context_provider_registry
-
-        _run_context_provider_registry.register(SparkAutologgingContext)
+        _listen_for_spark_activity(sc)
 
 
 def _get_repl_id():

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -7,6 +7,7 @@ import os
 import atexit
 import time
 import logging
+import inspect
 import numpy as np
 import pandas as pd
 
@@ -19,8 +20,11 @@ from mlflow.tracking.context import registry as context_registry
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.utils import env
 from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id
+from mlflow.utils.import_hooks import register_post_import_hook
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
 from mlflow.utils.validation import _validate_run_id
+
+from mlflow import tensorflow, keras, gluon, xgboost, lightgbm, spark, sklearn, fastai
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _EXPERIMENT_NAME_ENV_VAR = "MLFLOW_EXPERIMENT_NAME"
@@ -1021,3 +1025,55 @@ def _get_experiment_id():
         or _get_experiment_id_from_env()
         or (is_in_databricks_notebook() and get_notebook_id())
     ) or deprecated_default_exp_id
+
+
+def autolog(log_input_example=False, log_model_signature=True):  # pylint: disable=unused-argument
+    locals_copy = locals().items()
+
+    # Mapping of library module name to specific autolog function
+    # eg: mxnet.gluon is the actual library, mlflow.gluon.autolog is our autolog function for it
+    LIBRARY_TO_AUTOLOG_FN = {
+        "tensorflow": tensorflow.autolog,
+        "keras": keras.autolog,
+        "mxnet.gluon": gluon.autolog,
+        "xgboost": xgboost.autolog,
+        "lightgbm": lightgbm.autolog,
+        "sklearn": sklearn.autolog,
+        "fastai": fastai.autolog,
+        "pyspark": spark.autolog,
+    }
+
+    def setup_autologging(module):
+        autolog_fn = LIBRARY_TO_AUTOLOG_FN[module.__name__]
+        try:
+            needed_params = list(inspect.signature(autolog_fn).parameters.keys())
+            filtered = {k: v for k, v in locals_copy if k in needed_params}
+        except ValueError:
+            filtered = {}
+
+        try:
+            autolog_fn(**filtered)
+            _logger.info("Autologging successfully enabled for %s.", module.__name__)
+        except Exception as e:  # pylint: disable=broad-except
+            _logger.warning(
+                "Exception raised while enabling autologging for %s: %s", module.__name__, str(e)
+            )
+
+    # for each autolog library (except pyspark), register a post-import hook.
+    # this way, we do not send any errors to the user until we know they are using the library.
+    # the post-import hook also retroactively activates for previously-imported libraries.
+    for module in list(set(LIBRARY_TO_AUTOLOG_FN.keys()) - set(["pyspark"])):
+        register_post_import_hook(setup_autologging, module, overwrite=True)
+
+    # for pyspark, we activate autologging immediately, without waiting for a module import.
+    # this is because on Databricks a SparkSession already exists and the user can directly
+    #   interact with it, and this activity should be logged.
+    try:
+        spark.autolog()
+    except ImportError as ie:
+        # if pyspark isn't installed, a user could potentially install it in the middle
+        #   of their session so we want to enable autologging once they do
+        if "pyspark" in str(ie):
+            register_post_import_hook(setup_autologging, "pyspark", overwrite=True)
+    except Exception as e:  # pylint: disable=broad-except
+        _logger.warning("Exception raised while enabling autologging for spark: %s", str(e))

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -6,7 +6,7 @@ def _get_active_spark_session():
         return None
     try:
         # getActiveSession() only exists in Spark 3.0 and above
-        return SparkSession.builder.getActiveSession()
+        return SparkSession.getActiveSession()
     except Exception:  # pylint: disable=broad-except
         # Fall back to this internal field for Spark 2.x and below.
         return SparkSession._instantiatedSession

--- a/mlflow/utils/import_hooks/__init__.py
+++ b/mlflow/utils/import_hooks/__init__.py
@@ -1,0 +1,313 @@
+"""
+NOTE: The contents of this file have been inlined from the wrapt package's source code
+https://github.com/GrahamDumpleton/wrapt/blob/1.12.1/src/wrapt/importer.py.
+Some modifications, have been made in order to:
+    - avoid duplicate registration of import hooks
+    - inline functions from dependent wrapt submodules rather than importing them.
+
+This module implements a post import hook mechanism styled after what is described in PEP-369.
+Note that it doesn't cope with modules being reloaded.
+It also extends the functionality to support custom hooks for import errors
+(as opposed to only successful imports).
+"""
+
+import sys
+import threading
+
+import importlib  # pylint: disable=unused-import
+
+string_types = (str,)
+
+
+# from .decorators import synchronized
+# NOTE: Instead of using this import (from wrapt's decorator module, see
+# https://github.com/GrahamDumpleton/wrapt/blob/68316bea668fd905a4acb21f37f12596d8c30d80/src/wrapt/decorators.py#L430-L456),
+# we define a decorator with similar behavior that acquires a lock while calling the decorated
+# function
+def synchronized(lock):
+    def decorator(f):
+        # See e.g. https://www.python.org/dev/peps/pep-0318/#examples
+        def new_fn(*args, **kwargs):
+            with lock:
+                return f(*args, **kwargs)
+
+        return new_fn
+
+    return decorator
+
+
+# The dictionary registering any post import hooks to be triggered once
+# the target module has been imported. Once a module has been imported
+# and the hooks fired, the list of hooks recorded against the target
+# module will be truncacted but the list left in the dictionary. This
+# acts as a flag to indicate that the module had already been imported.
+
+_post_import_hooks = {}
+_post_import_hooks_lock = threading.RLock()
+
+# A dictionary for any import hook error handlers to be triggered when the
+# target module import fails.
+
+_import_error_hooks = {}
+_import_error_hooks_lock = threading.RLock()
+
+_import_hook_finder_init = False
+
+# Register a new post import hook for the target module name. This
+# differs from the PEP-369 implementation in that it also allows the
+# hook function to be specified as a string consisting of the name of
+# the callback in the form 'module:function'. This will result in a
+# proxy callback being registered which will defer loading of the
+# specified module containing the callback function until required.
+
+
+def _create_import_hook_from_string(name):
+    def import_hook(module):
+        module_name, function = name.split(":")
+        attrs = function.split(".")
+        __import__(module_name)
+        callback = sys.modules[module_name]
+        for attr in attrs:
+            callback = getattr(callback, attr)
+        return callback(module)
+
+    return import_hook
+
+
+def register_generic_import_hook(hook, name, hook_dict, overwrite):
+    # Create a deferred import hook if hook is a string name rather than
+    # a callable function.
+
+    if isinstance(hook, string_types):
+        hook = _create_import_hook_from_string(hook)
+
+    # Automatically install the import hook finder if it has not already
+    # been installed.
+
+    global _import_hook_finder_init
+    if not _import_hook_finder_init:
+        _import_hook_finder_init = True
+        sys.meta_path.insert(0, ImportHookFinder())
+
+    # Determine if any prior registration of an import hook for
+    # the target modules has occurred and act appropriately.
+
+    hooks = hook_dict.get(name, None)
+
+    if hooks is None:
+        # No prior registration of import hooks for the target
+        # module. We need to check whether the module has already been
+        # imported. If it has we fire the hook immediately and add an
+        # empty list to the registry to indicate that the module has
+        # already been imported and hooks have fired. Otherwise add
+        # the post import hook to the registry.
+
+        module = sys.modules.get(name, None)
+
+        if module is not None:
+            hook_dict[name] = []
+            hook(module)
+
+        else:
+            hook_dict[name] = [hook]
+
+    elif hooks == []:
+        # A prior registration of import hooks for the target
+        # module was done and the hooks already fired. Fire the hook
+        # immediately.
+
+        module = sys.modules[name]
+        hook(module)
+
+    else:
+        # A prior registration of import hooks for the target
+        # module was done but the module has not yet been imported.
+
+        def hooks_equal(existing_hook, hook):
+            if hasattr(existing_hook, "__name__") and hasattr(hook, "__name__"):
+                return existing_hook.__name__ == hook.__name__
+            else:
+                return False
+
+        if overwrite:
+            hook_dict[name] = [
+                existing_hook
+                for existing_hook in hook_dict[name]
+                if not hooks_equal(existing_hook, hook)
+            ]
+
+        hook_dict[name].append(hook)
+
+
+@synchronized(_import_error_hooks_lock)
+def register_import_error_hook(hook, name, overwrite=True):
+    """
+    :param hook: A function or string entrypoint to invoke when the specified module is imported
+                 and an error occurs.
+    :param name: The name of the module for which to fire the hook at import error detection time.
+    :param overwrite: Specifies the desired behavior when a preexisting hook for the same
+                      function / entrypoint already exists for the specified module. If `True`,
+                      all preexisting hooks matching the specified function / entrypoint will be
+                      removed and replaced with a single instance of the specified `hook`.
+    """
+    register_generic_import_hook(hook, name, _import_error_hooks, overwrite)
+
+
+@synchronized(_post_import_hooks_lock)
+def register_post_import_hook(hook, name, overwrite=True):
+    """
+    :param hook: A function or string entrypoint to invoke when the specified module is imported.
+    :param name: The name of the module for which to fire the hook at import time.
+    :param overwrite: Specifies the desired behavior when a preexisting hook for the same
+                      function / entrypoint already exists for the specified module. If `True`,
+                      all preexisting hooks matching the specified function / entrypoint will be
+                      removed and replaced with a single instance of the specified `hook`.
+    """
+    register_generic_import_hook(hook, name, _post_import_hooks, overwrite)
+
+
+# Register post import hooks defined as package entry points.
+
+
+def _create_import_hook_from_entrypoint(entrypoint):
+    def import_hook(module):
+        __import__(entrypoint.module_name)
+        callback = sys.modules[entrypoint.module_name]
+        for attr in entrypoint.attrs:
+            callback = getattr(callback, attr)
+        return callback(module)
+
+    return import_hook
+
+
+def discover_post_import_hooks(group):
+    try:
+        import pkg_resources
+    except ImportError:
+        return
+
+    for entrypoint in pkg_resources.iter_entry_points(group=group):
+        callback = _create_import_hook_from_entrypoint(entrypoint)
+        register_post_import_hook(callback, entrypoint.name)
+
+
+# Indicate that a module has been loaded. Any post import hooks which
+# were registered against the target module will be invoked. If an
+# exception is raised in any of the post import hooks, that will cause
+# the import of the target module to fail.
+
+
+@synchronized(_post_import_hooks_lock)
+def notify_module_loaded(module):
+    name = getattr(module, "__name__", None)
+    hooks = _post_import_hooks.get(name, None)
+
+    if hooks:
+        _post_import_hooks[name] = []
+
+        for hook in hooks:
+            hook(module)
+
+
+@synchronized(_import_error_hooks_lock)
+def notify_module_import_error(module_name):
+    hooks = _import_error_hooks.get(module_name, None)
+
+    if hooks:
+        # Error hooks differ from post import hooks, in that we don't clear the
+        # hook as soon as it fires.
+        for hook in hooks:
+            hook(module_name)
+
+
+# A custom module import finder. This intercepts attempts to import
+# modules and watches out for attempts to import target modules of
+# interest. When a module of interest is imported, then any post import
+# hooks which are registered will be invoked.
+
+
+class _ImportHookChainedLoader:
+    def __init__(self, loader):
+        self.loader = loader
+
+    def load_module(self, fullname):
+        try:
+            module = self.loader.load_module(fullname)
+            notify_module_loaded(module)
+        except (ImportError, AttributeError):
+            notify_module_import_error(fullname)
+            raise
+
+        return module
+
+
+class ImportHookFinder:
+    def __init__(self):
+        self.in_progress = {}
+
+    @synchronized(_post_import_hooks_lock)
+    @synchronized(_import_error_hooks_lock)
+    def find_module(self, fullname, path=None):
+        # If the module being imported is not one we have registered
+        # import hooks for, we can return immediately. We will
+        # take no further part in the importing of this module.
+
+        if fullname not in _post_import_hooks and fullname not in _import_error_hooks:
+            return None
+
+        # When we are interested in a specific module, we will call back
+        # into the import system a second time to defer to the import
+        # finder that is supposed to handle the importing of the module.
+        # We set an in progress flag for the target module so that on
+        # the second time through we don't trigger another call back
+        # into the import system and cause a infinite loop.
+
+        if fullname in self.in_progress:
+            return None
+
+        self.in_progress[fullname] = True
+
+        # Now call back into the import system again.
+
+        try:
+            # For Python 3 we need to use find_spec().loader
+            # from the importlib.util module. It doesn't actually
+            # import the target module and only finds the
+            # loader. If a loader is found, we need to return
+            # our own loader which will then in turn call the
+            # real loader to import the module and invoke the
+            # post import hooks.
+            try:
+                import importlib.util
+
+                loader = importlib.util.find_spec(fullname).loader
+            # If an ImportError (or AttributeError) is encountered while finding the module,
+            # notify the hooks for import errors
+            except (ImportError, AttributeError):
+                notify_module_import_error(fullname)
+                loader = importlib.find_loader(fullname, path)  # pylint: disable=deprecated-method
+            if loader:
+                return _ImportHookChainedLoader(loader)
+        finally:
+            del self.in_progress[fullname]
+
+
+# Decorator for marking that a function should be called as a post
+# import hook when the target module is imported.
+# If error_handler is True, then apply the marked function as an import hook
+# for import errors (instead of successful imports).
+# It is assumed that all error hooks are added during driver start-up,
+# and thus added prior to any import calls. If an error hook is added
+# after a module has already failed the import, there's no guarantee
+# that the hook will fire.
+
+
+def when_imported(name, error_handler=False):
+    def register(hook):
+        if error_handler:
+            register_import_error_hook(hook, name)
+        else:
+            register_post_import_hook(hook, name)
+        return hook
+
+    return register

--- a/tests/spark_autologging/test_spark_datasource_autologging.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging.py
@@ -42,6 +42,10 @@ def _get_expected_table_info_row(path, data_format, version=None):
     )
 
 
+# Note that the following tests run one-after-the-other and operate on the SAME spark_session
+#   (it is not reset between tests)
+
+
 @pytest.mark.large
 def test_autologging_of_datasources_with_different_formats(spark_session, format_to_file_path):
     mlflow.spark.autolog()

--- a/tests/spark_autologging/test_spark_datasource_autologging_missing_jar.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_missing_jar.py
@@ -13,6 +13,6 @@ def test_enabling_autologging_throws_for_missing_jar():
     try:
         with pytest.raises(MlflowException) as exc:
             mlflow.spark.autolog()
-        assert "Please ensure you have the mlflow-spark JAR attached" in exc.value.message
+        assert "ensure you have the mlflow-spark JAR attached" in exc.value.message
     finally:
         spark_session.stop()

--- a/tests/spark_autologging/test_spark_datasource_autologging_order.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_order.py
@@ -1,0 +1,48 @@
+import pytest
+
+import mlflow
+import mlflow.spark
+import tempfile
+import os
+import shutil
+import time
+
+from pyspark.sql import Row
+from pyspark.sql.types import StructType, IntegerType, StructField
+
+from tests.spark_autologging.utils import _get_or_create_spark_session
+from tests.spark_autologging.utils import _assert_spark_data_logged
+
+
+@pytest.mark.large
+def test_enabling_autologging_before_spark_session_works():
+    mlflow.spark.autolog()
+
+    # creating spark session AFTER autolog was enabled
+    spark_session = _get_or_create_spark_session()
+
+    rows = [Row(100)]
+    schema = StructType([StructField("number2", IntegerType())])
+    rdd = spark_session.sparkContext.parallelize(rows)
+    df = spark_session.createDataFrame(rdd, schema)
+    tempdir = tempfile.mkdtemp()
+    filepath = os.path.join(tempdir, "test-data")
+    df.write.option("header", "true").format("csv").save(filepath)
+
+    read_df = (
+        spark_session.read.format("csv")
+        .option("header", "true")
+        .option("inferSchema", "true")
+        .load(filepath)
+    )
+
+    with mlflow.start_run():
+        run_id = mlflow.active_run().info.run_id
+        read_df.collect()
+        time.sleep(1)
+
+    run = mlflow.get_run(run_id)
+    _assert_spark_data_logged(run=run, path=filepath, data_format="csv")
+
+    shutil.rmtree(tempdir)
+    spark_session.stop()

--- a/tests/spark_autologging/test_spark_datasource_autologging_unit.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_unit.py
@@ -49,17 +49,7 @@ def test_enabling_autologging_throws_for_wrong_spark_version(
     # pylint: disable=unused-argument
     with mock.patch("mlflow._spark_autologging._get_spark_major_version") as get_version_mock:
         get_version_mock.return_value = 2
+
         with pytest.raises(MlflowException) as exc:
             mlflow.spark.autolog()
         assert "Spark autologging unsupported for Spark versions < 3" in exc.value.message
-
-
-@pytest.mark.large
-def test_enabling_autologging_throws_when_spark_hasnt_been_started(
-    spark_session, mock_get_current_listener
-):
-    # pylint: disable=unused-argument
-    spark_session.stop()
-    with pytest.raises(MlflowException) as exc:
-        mlflow.spark.autolog()
-    assert "No active SparkContext found" in exc.value.message

--- a/tests/spark_autologging/utils.py
+++ b/tests/spark_autologging/utils.py
@@ -44,7 +44,7 @@ def _get_or_create_spark_session(jars=None):
     return SparkSession.builder.config("spark.jars", jar_path).master("local[*]").getOrCreate()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def spark_session():
     jar_path = _get_mlflow_spark_jar_path()
     session = SparkSession.builder.config("spark.jars", jar_path).master("local[*]").getOrCreate()

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -41,8 +41,6 @@ from mlflow.tracking.fluent import (
 from mlflow.utils import mlflow_tags
 from mlflow.utils.file_utils import TempDir
 
-# pylint: disable=unused-argument
-
 
 class HelperEnv:
     def __init__(self):
@@ -248,7 +246,7 @@ def is_from_run(active_run, run):
     return active_run.info == run.info and active_run.data == run.data
 
 
-def test_start_run_defaults(empty_active_run_stack):
+def test_start_run_defaults(empty_active_run_stack):  # pylint: disable=unused-argument
 
     mock_experiment_id = mock.Mock()
     experiment_id_patch = mock.patch(
@@ -290,7 +288,9 @@ def test_start_run_defaults(empty_active_run_stack):
         assert is_from_run(active_run, MlflowClient.create_run.return_value)
 
 
-def test_start_run_defaults_databricks_notebook(empty_active_run_stack):
+def test_start_run_defaults_databricks_notebook(
+    empty_active_run_stack,
+):  # pylint: disable=unused-argument
 
     mock_experiment_id = mock.Mock()
     experiment_id_patch = mock.patch(
@@ -382,7 +382,7 @@ def test_start_run_with_parent_non_nested():
             start_run()
 
 
-def test_start_run_existing_run(empty_active_run_stack):
+def test_start_run_existing_run(empty_active_run_stack):  # pylint: disable=unused-argument
     mock_run = mock.Mock()
     mock_run.info.lifecycle_stage = LifecycleStage.ACTIVE
 
@@ -396,7 +396,9 @@ def test_start_run_existing_run(empty_active_run_stack):
         MlflowClient.get_run.assert_called_with(run_id)
 
 
-def test_start_run_existing_run_from_environment(empty_active_run_stack):
+def test_start_run_existing_run_from_environment(
+    empty_active_run_stack,
+):  # pylint: disable=unused-argument
     mock_run = mock.Mock()
     mock_run.info.lifecycle_stage = LifecycleStage.ACTIVE
 
@@ -413,7 +415,9 @@ def test_start_run_existing_run_from_environment(empty_active_run_stack):
         MlflowClient.get_run.assert_called_with(run_id)
 
 
-def test_start_run_existing_run_from_environment_with_set_environment(empty_active_run_stack):
+def test_start_run_existing_run_from_environment_with_set_environment(
+    empty_active_run_stack,
+):  # pylint: disable=unused-argument
     mock_run = mock.Mock()
     mock_run.info.lifecycle_stage = LifecycleStage.ACTIVE
 
@@ -426,7 +430,7 @@ def test_start_run_existing_run_from_environment_with_set_environment(empty_acti
             start_run()
 
 
-def test_start_run_existing_run_deleted(empty_active_run_stack):
+def test_start_run_existing_run_deleted(empty_active_run_stack):  # pylint: disable=unused-argument
     mock_run = mock.Mock()
     mock_run.info.lifecycle_stage = LifecycleStage.DELETED
 
@@ -437,7 +441,7 @@ def test_start_run_existing_run_deleted(empty_active_run_stack):
             start_run(run_id)
 
 
-def test_start_existing_run_status(empty_active_run_stack):
+def test_start_existing_run_status(empty_active_run_stack):  # pylint: disable=unused-argument
     run_id = mlflow.start_run().info.run_id
     mlflow.end_run()
     assert MlflowClient().get_run(run_id).info.status == RunStatus.to_string(RunStatus.FINISHED)
@@ -445,7 +449,7 @@ def test_start_existing_run_status(empty_active_run_stack):
     assert restarted_run.info.status == RunStatus.to_string(RunStatus.RUNNING)
 
 
-def test_start_existing_run_end_time(empty_active_run_stack):
+def test_start_existing_run_end_time(empty_active_run_stack):  # pylint: disable=unused-argument
     run_id = mlflow.start_run().info.run_id
     mlflow.end_run()
     run_obj_info = MlflowClient().get_run(run_id).info

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -1,0 +1,153 @@
+import pytest
+from unittest import mock
+import inspect
+
+import mlflow
+
+import tensorflow
+import keras
+import fastai
+import sklearn
+import xgboost
+import lightgbm
+import mxnet.gluon
+import pyspark
+
+library_to_mlflow_module_without_pyspark = {
+    tensorflow: "tensorflow",
+    keras: "keras",
+    fastai: "fastai",
+    sklearn: "sklearn",
+    xgboost: "xgboost",
+    lightgbm: "lightgbm",
+    mxnet.gluon: "gluon",
+}
+
+library_to_mlflow_module = {**library_to_mlflow_module_without_pyspark, pyspark: "spark"}
+
+
+@pytest.fixture(autouse=True)
+def reset_global_states():
+    for integration_name in library_to_mlflow_module.keys():
+        try:
+            del mlflow.utils.import_hooks._post_import_hooks[integration_name.__name__]
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    assert mlflow.utils.import_hooks._post_import_hooks == {}
+
+    yield
+
+    for integration_name in library_to_mlflow_module.keys():
+        try:
+            del mlflow.utils.import_hooks._post_import_hooks[integration_name.__name__]
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    assert mlflow.utils.import_hooks._post_import_hooks == {}
+
+
+# We are pretending the module is not already imported (in reality it is, at the top of this file),
+#   and is only imported when we call wrapt.notify_module_loaded in the tests below. Normally,
+#   notify_module_loaded would be called by register_post_import_hook if it sees that the module
+#   is already loaded.
+def only_register(callback_fn, module, overwrite):  # pylint: disable=unused-argument
+    mlflow.utils.import_hooks._post_import_hooks[module] = [callback_fn]
+
+
+@pytest.fixture(autouse=True)
+def disable_new_import_hook_firing_if_module_already_exists():
+    with mock.patch("mlflow.tracking.fluent.register_post_import_hook", wraps=only_register):
+        yield
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("library,mlflow_module", library_to_mlflow_module.items())
+def test_universal_autolog_does_not_throw_if_specific_autolog_throws(library, mlflow_module):
+    with mock.patch("mlflow." + mlflow_module + ".autolog") as autolog_mock:
+        autolog_mock.side_effect = Exception("asdf")
+        mlflow.autolog()
+        if library != pyspark:
+            autolog_mock.assert_not_called()
+        mlflow.utils.import_hooks.notify_module_loaded(library)
+        autolog_mock.assert_called_once()
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("library,mlflow_module", library_to_mlflow_module_without_pyspark.items())
+def test_universal_autolog_calls_specific_autologs_correctly(library, mlflow_module):
+    integrations_with_config = [xgboost, lightgbm, sklearn]
+
+    # modify the __signature__ of the mock to contain the needed parameters
+    args = (
+        {"log_input_example": bool, "log_model_signature": bool}
+        if library in integrations_with_config
+        else {}
+    )
+    params = [
+        inspect.Parameter(param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=type_)
+        for param, type_ in args.items()
+    ]
+    with mock.patch(
+        "mlflow." + mlflow_module + ".autolog", wraps=getattr(mlflow, mlflow_module).autolog
+    ) as autolog_mock:
+        autolog_mock.__signature__ = inspect.Signature(params)
+
+        autolog_mock.assert_not_called()
+
+        # this should attach import hooks to each library
+        mlflow.autolog(log_input_example=True, log_model_signature=True)
+
+        autolog_mock.assert_not_called()
+
+        mlflow.utils.import_hooks.notify_module_loaded(library)
+
+        # after each library is imported, its corresponding autolog function should have been called
+        if library in integrations_with_config:
+            autolog_mock.assert_called_once_with(log_input_example=True, log_model_signature=True)
+        else:
+            autolog_mock.assert_called_once_with()
+
+
+@pytest.mark.large
+def test_universal_autolog_calls_pyspark_immediately():
+    library = pyspark
+    mlflow_module = "spark"
+
+    with mock.patch(
+        "mlflow." + mlflow_module + ".autolog", wraps=getattr(mlflow, mlflow_module).autolog
+    ) as autolog_mock:
+        autolog_mock.assert_not_called()
+
+        mlflow.autolog()
+
+        # pyspark autolog should NOT wait for pyspark to be imported
+        # it should instead initialize autologging immediately
+        autolog_mock.assert_called_once_with()
+
+        # there should also be no import hook on pyspark
+        mlflow.utils.import_hooks.notify_module_loaded(library)
+        autolog_mock.assert_called_once_with()
+
+
+@pytest.mark.large
+def test_universal_autolog_attaches_pyspark_import_hook_if_pyspark_isnt_installed():
+    library = pyspark
+    mlflow_module = "spark"
+
+    with mock.patch(
+        "mlflow." + mlflow_module + ".autolog", wraps=getattr(mlflow, mlflow_module).autolog
+    ) as autolog_mock:
+        # simulate pyspark not being installed
+        autolog_mock.side_effect = ImportError("no module named pyspark blahblah")
+
+        mlflow.autolog()
+        autolog_mock.assert_called_once()  # it was called once and failed
+
+        # now the user installs pyspark
+        autolog_mock.side_effect = None
+
+        mlflow.utils.import_hooks.notify_module_loaded(library)
+
+        # assert autolog is called again once pyspark is imported
+        assert autolog_mock.call_count == 2


### PR DESCRIPTION
* stash

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* commit import test

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stash

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stash

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* idk

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stash changes

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* i think this works...

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* remove logging msg

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* revert some changes

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* revert blank line

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* commit changes

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stash

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stash

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* this is the best i could do

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* add some comments

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fix linting

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* mark test as large

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* move universal autolog to fluent module

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* pls work

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* remove assert that autolog was not called before module was imported

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* revert signature entity change

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* maybe works?

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stash

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* working kinda?

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* handle where session exists but mlflow-spark jar is not attached'

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stash

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stash

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* finally working i think?

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* Revert changes to spark testing script

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fix missing jar test

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* attempt to change test to capture logging msg

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* revert changes to testing script

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* revert new pom

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* revert changes to pom.xml

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* revert print

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fmt all

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fix remaining tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fmt

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* retrigger tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* revert spark example

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* code review

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* more code review

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fmt

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* temp example change

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* improve tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* add test to ensure a throwing specific autolog does not cause mlflow.autolog to throw

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* formatting

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* tests working?

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* working now

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* small fixes and reverts

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* add log messages for when autologging is enabled for a specific library

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* decrement pytest-mock to hopefully work with our old pytest??

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* do better job of cleaning up imports both before and after autolog tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* do better job of cleaning up imports both before and after autolog tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* move resetting of global states to a fixture

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* pytest-mock older version somehow broke our tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stash

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* cleanup

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* stop using pytest-mock

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* remove references to mocker

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* retrigger tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* potential fix for import error in tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fix tests plssss

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* add libraries to small-requirements

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* tests pls

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* bump test versino of pyspark to 3.0.0

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* update test comments

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* test moving ml libraries to large-requirements

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* move universal autolog tests to different file and mark as large

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* move autologging enabled message for spark to only show when a spark session exists or is created

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* try to fix tests??

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* Safe shutdown

Signed-off-by: Corey Zumar <corey.zumar@databricks.com>
Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* Wrapt

Signed-off-by: Corey Zumar <corey.zumar@databricks.com>
Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* Wrapt

Signed-off-by: Corey Zumar <corey.zumar@databricks.com>
Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* Docs

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* Format

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* retrigger tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* retrigger tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* Remove string "databricks" from comment

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fix fluent autolog tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* assert resetting the state and fix inconsistent dict

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fix pytest linting

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fix pycodestyle lint errors

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* do not ignore fluent_autolog tests

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* fix test config hopefully

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* assert that fluent_autolog test IS being run

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

* revert 'assert that fluent_autolog test IS being run'

Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

Co-authored-by: Corey Zumar <corey.zumar@databricks.com>
Co-authored-by: dbczumar <39497902+dbczumar@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
